### PR TITLE
Add covers network

### DIFF
--- a/brute.go
+++ b/brute.go
@@ -108,6 +108,23 @@ func (b *bruteRanger) CoveredNetworks(network net.IPNet) ([]RangerEntry, error) 
 	return results, nil
 }
 
+// CoversNetwork returns boolean indicating whether given ipnet is covered by any
+// of the inserted networks.
+func (b *bruteRanger) CoversNetwork(network net.IPNet) (bool, error) {
+	entries, err := b.getEntriesByVersion(network.IP)
+	if err != nil {
+		return false, err
+	}
+	testNetwork := rnet.NewNetwork(network)
+	for _, entry := range entries {
+		entryNetwork := rnet.NewNetwork(entry.Network())
+		if entryNetwork.Covers(testNetwork) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // Len returns number of networks in ranger.
 func (b *bruteRanger) Len() int {
 	return len(b.ipV4Entries) + len(b.ipV6Entries)

--- a/cidranger.go
+++ b/cidranger.go
@@ -88,6 +88,7 @@ type Ranger interface {
 	Contains(ip net.IP) (bool, error)
 	ContainingNetworks(ip net.IP) ([]RangerEntry, error)
 	CoveredNetworks(network net.IPNet) ([]RangerEntry, error)
+	CoversNetwork(network net.IPNet) (bool, error)
 	Len() int
 }
 

--- a/version.go
+++ b/version.go
@@ -61,6 +61,14 @@ func (v *versionedRanger) CoveredNetworks(network net.IPNet) ([]RangerEntry, err
 	return ranger.CoveredNetworks(network)
 }
 
+func (v *versionedRanger) CoversNetwork(network net.IPNet) (bool, error) {
+	ranger, err := v.getRangerForIP(network.IP)
+	if err != nil {
+		return false, err
+	}
+	return ranger.CoversNetwork(network)
+}
+
 // Len returns number of networks in ranger.
 func (v *versionedRanger) Len() int {
 	return v.ipV4Ranger.Len() + v.ipV6Ranger.Len()


### PR DESCRIPTION
Added a method on the prefix trie to check if a network is covered by the insert networks. Also created unit tests following the approach in existing tests and benchmarks.  

The prefix trie implementation provides good benchmark results in both search hit and miss cases, comparing to the brute ranger, presented below:

```
goos: linux
goarch: amd64
pkg: github.com/libp2p/go-cidranger
cpu: Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz
BenchmarkPCTrieHitIPv4UsingAWSRanges-4                           	  468722	      2621 ns/op
BenchmarkBruteRangerHitIPv4UsingAWSRanges-4                      	   13744	     74216 ns/op
BenchmarkPCTrieHitIPv6UsingAWSRanges-4                           	 1294831	       981.0 ns/op
BenchmarkBruteRangerHitIPv6UsingAWSRanges-4                      	   88040	     15865 ns/op
BenchmarkPCTrieMissIPv4UsingAWSRanges-4                          	 1956492	       714.0 ns/op
BenchmarkBruteRangerMissIPv4UsingAWSRanges-4                     	    8949	    125386 ns/op
BenchmarkPCTrieHMissIPv6UsingAWSRanges-4                         	 1314266	      1014 ns/op
BenchmarkBruteRangerMissIPv6UsingAWSRanges-4                     	   21070	     53556 ns/op
BenchmarkPCTrieHitContainingNetworksIPv4UsingAWSRanges-4         	  415922	      3320 ns/op
BenchmarkBruteRangerHitContainingNetworksIPv4UsingAWSRanges-4    	    7195	    149444 ns/op
BenchmarkPCTrieHitContainingNetworksIPv6UsingAWSRanges-4         	  302386	      3335 ns/op
BenchmarkBruteRangerHitContainingNetworksIPv6UsingAWSRanges-4    	   19921	     51883 ns/op
BenchmarkPCTrieMissContainingNetworksIPv4UsingAWSRanges-4        	 1789305	       717.0 ns/op
BenchmarkBruteRangerMissContainingNetworksIPv4UsingAWSRanges-4   	    9250	    129556 ns/op
BenchmarkPCTrieHMissContainingNetworksIPv6UsingAWSRanges-4       	 1270513	       851.9 ns/op
BenchmarkBruteRangerMissContainingNetworksIPv6UsingAWSRanges-4   	   23017	     52864 ns/op
BenchmarkPCTrieHitCoversNetworkIPv4UsingAWSRanges-4              	  439429	      2531 ns/op
BenchmarkBruteRangerHitCoversNetworkIPv4UsingAWSRanges-4         	    7004	    154875 ns/op
BenchmarkPCTrieHitCoversNetworkIPv6UsingAWSRanges-4              	  768741	      1991 ns/op
BenchmarkBruteRangerHitCoversNetworkIPv6UsingAWSRanges-4         	   10000	    113279 ns/op
BenchmarkPCTrieMissCoversNetworkIPv4UsingAWSRanges-4             	 1979072	       701.1 ns/op
BenchmarkBruteRangerMissCoversNetworkIPv4UsingAWSRanges-4        	    3642	    301736 ns/op
BenchmarkPCTrieMissCoversNetworkIPv6UsingAWSRanges-4             	 1517984	       824.3 ns/op
BenchmarkBruteRangerMissCoversNetworkIPv6UsingAWSRanges-4        	    7500	    169884 ns/op
```
